### PR TITLE
Fix markdown headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,14 @@ css-inline-images
 
 Simple node module for inlining images as base64 strings in CSS.
 
-##Installation
+## Installation
+
 Install with NPM like any other package
 ```bash
 npm install css-inline-images
 ```
 
-##Usage
+## Usage
 Append `?embed` to the urls of the images that you want inlined
 
 ```javascript
@@ -35,7 +36,8 @@ outputCss = cssInlineImages(inputCss, {
 
 The module will search for `url()` declarations in your CSS code so its use is not limited to background images.
 
-##Options
+## Options
+
 * `webRoot`
   The web root of your web project. This property will be used as a start point for all file paths.
   This is enough for absolute urls (e.g.  `url(/images/file.gif?embed)`)
@@ -43,7 +45,8 @@ The module will search for `url()` declarations in your CSS code so its use is n
 * `path`
   Used in addition to `webRoot` to determine the paths for relative urls (e.g. `url(images/file.gif?embed)`)
 
-###Example
+### Example
+
 With these options the following paths will be used to locate the images in the filesystem
 ```javascript
 {


### PR DESCRIPTION
To properly display headers they should have a newline before and after themselves.